### PR TITLE
Improve platformio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ builds/
 ext_def.h
 logos-custom.h
 configuration.h
-
+logs

--- a/platformio.ini
+++ b/platformio.ini
@@ -61,69 +61,6 @@ extra_scripts = platformio_script.py
 ;platform_version_esp32 = espressif32@1.11.1 ; using Arduino core 1.0.4
 ;platform_version_esp32 = espressif32
 
-[env:esp32dev]
-;ARDUINO_ESP32_DEV
-monitor_speed = 115200
-; monitor_port = /dev/cu.SLAB_USBtoUART
-lang = fr
-;platform = espressif32
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
-;platform = espressif32@5.2.0
-;platform = https://github.com/Jason2866/platform-espressif32
-;platform = espressif32@1.11.1
-;platform = ${common.platform_version_esp32}
-board = esp32dev
-framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C' ;'-DCORE_DEBUG_LEVEL=5'
-lib_deps = 
-  ${common.lib_deps_esp32}
-  mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-  ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
-extra_scripts = ${common.extra_scripts}
-
-
-[env:esp32dev_fr]
-;ARDUINO_ESP32_DEV
-monitor_speed = 115200
-; monitor_port = /dev/cu.SLAB_USBtoUART
-lang = fr
-;platform = espressif32
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
-;platform = espressif32@5.2.0
-;platform = https://github.com/Jason2866/platform-espressif32
-;platform = espressif32@1.11.1
-;platform = ${common.platform_version_esp32}
-board = esp32dev
-framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C' ;'-DCORE_DEBUG_LEVEL=5'
-lib_deps = 
-  ${common.lib_deps_esp32}
-  mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-  ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
-extra_scripts = ${common.extra_scripts}
-
-
-[env:esp32dev_en]
-;ARDUINO_ESP32_DEV
-monitor_speed = 115200
-; monitor_port = /dev/cu.SLAB_USBtoUART
-lang = en
-;platform = espressif32
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
-;platform = espressif32@5.2.0
-;platform = https://github.com/Jason2866/platform-espressif32
-;platform = espressif32@1.11.1
-;platform = ${common.platform_version_esp32}
-board = esp32dev
-framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_EN' '-DKIT_C' ;'-DCORE_DEBUG_LEVEL=5'
-lib_deps = 
-  ${common.lib_deps_esp32}
-  mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-  ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
-extra_scripts = ${common.extra_scripts}
-
-
 [env:esp32doit-devkit-v1]
 ;ARDUINO_ESP32_DEV
 monitor_speed = 115200
@@ -138,10 +75,3 @@ lib_deps =
   mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
   ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 extra_scripts = ${common.extra_scripts}
-
-; RAM:   [==        ]  17.0% (used 55864 bytes from 327680 bytes)
-; Flash: [========= ]  86.1% (used 1129174 bytes from 1310720 bytes)
-
-;AJOUTER  board_build.partitions = min_spiffs.csv ???
-; RAM:   [==        ]  17.0% (used 55864 bytes from 327680 bytes)
-; Flash: [======    ]  57.4% (used 1129174 bytes from 1966080 bytes)

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,7 @@
 src_dir = .
 description = Software for the DOIT ESP32 DEVKIT V1 running inside the air quality sensor ModuleAir.
 name = ModuleAir_V2.1
+default_envs = esp32doit-devkit-v1-debug
 
 [common]
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,3 +89,18 @@ framework = arduino
 build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
 lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}
+
+[env:esp32dev-en-debug]
+monitor_speed = 115200
+build_type = debug
+monitor_filters = 
+	default
+	log2file
+	esp32_exception_decoder
+platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
+lang = fr
+board = esp32dev
+framework = arduino
+build_flags = ${common.build_flags_esp32_release} '-DINTL_EN' '-DKIT_C'
+lib_deps = ${common.lib_deps_esp32}
+extra_scripts = ${common.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,94 +1,91 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
 [platformio]
 src_dir = .
 
 [common]
 monitor_speed = 115200
-build_flags =
-  -DVTABLES_IN_FLASH
-  -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-  -D HTTPCLIENT_1_1_COMPATIBLE=0 
-  ;-D NO_GLOBAL_SERIAL=0
-  -DNDEBUG -DFP_IN_IROM -frandom-seed=b61f78373
-  ; -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
-  ; -D CFG_eu868=1
-  ; -D CFG_sx1276_radio=1
-  ; -D LMIC_LORAWAN_SPEC_VERSION=LMIC_LORAWAN_SPEC_VERSION_1_0_3
-  ; -D MONITOR_SPEED=115200
-  ; -D LMIC_PRINTF_TO=Serial
-
-build_flags_esp32 =
-  -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-  -DVTABLES_IN_FLASH -DBEARSSL_SSL_BASIC
-  -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
-  -D CFG_eu868=1
-  -D CFG_sx1276_radio=1
-  -D LMIC_LORAWAN_SPEC_VERSION=LMIC_LORAWAN_SPEC_VERSION_1_0_3
-  -D hal_init=LMICHAL_init
-  -D MONITOR_SPEED=115200
-  -D LMIC_PRINTF_TO=Serial
-  
-  
+build_flags = 
+	-DVTABLES_IN_FLASH
+	-D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+	-D HTTPCLIENT_1_1_COMPATIBLE=0
+	-DNDEBUG -DFP_IN_IROM -frandom-seed=b61f78373
+build_flags_esp32 = 
+	-DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+	-DVTABLES_IN_FLASH -DBEARSSL_SSL_BASIC
+	-D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
+	-D CFG_eu868=1
+	-D CFG_sx1276_radio=1
+	-D LMIC_LORAWAN_SPEC_VERSION=LMIC_LORAWAN_SPEC_VERSION_1_0_3
+	-D hal_init=LMICHAL_init
+	-D MONITOR_SPEED=115200
+	-D LMIC_PRINTF_TO=Serial
 build_flags_esp32_release = ${common.build_flags_esp32} -DNDEBUG
 build_flags_esp32_debug = ${common.build_flags_esp32} -g -Og -fno-inline -DUSING_JTAG_DEBUGGER_PINS=1 -DDEBUG_ESP_PORT=Serial
-
 board_build.ldscript = eagle.flash.4m3m.ld
 board_build.filesystem = spiffs
 board_build.f_cpu = 160000000L
-
-lib_deps_external =
-  bblanchon/ArduinoJson@6.18.3
-  2dom/PxMatrix LED MATRIX library@^1.8.2
-  adafruit/Adafruit GFX Library@^1.10.12
+lib_deps_external = 
+	bblanchon/ArduinoJson@6.18.3
+	2dom/PxMatrix LED MATRIX library@^1.8.2
+	adafruit/Adafruit GFX Library@^1.10.12
 	adafruit/Adafruit BusIO@^1.9.8
-  https://github.com/IntarBV/MHZ16_uart
+	https://github.com/IntarBV/MHZ16_uart
 	https://github.com/WifWaf/MH-Z19.git
-  maarten-pennings/CCS811 @ ^12.0.0
-
-lib_deps_esp32_platform =
-  Wire
-  WiFi
-  DNSServer
-  WiFiClientSecure
-  HTTPClient
-  FS
-  SPIFFS
-  WebServer
-  Update
-  ESPmDNS
-
+	maarten-pennings/CCS811 @ ^12.0.0
+lib_deps_esp32_platform = 
+	Wire
+	WiFi
+	DNSServer
+	WiFiClientSecure
+	HTTPClient
+	FS
+	SPIFFS
+	WebServer
+	Update
+	ESPmDNS
 lib_deps_esp32 = ${common.lib_deps_esp32_platform} ${common.lib_deps_external}
 extra_scripts = platformio_script.py
 ;platform_version_esp32 = espressif32@1.11.1 ; using Arduino core 1.0.4
 ;platform_version_esp32 = espressif32
 
 [env:esp32doit-devkit-v1]
-;ARDUINO_ESP32_DEV
 monitor_speed = 115200
-;board_build.partitions = min_spiffs.csv
+platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
 lang = fr
-platform = espressif32@4.1.0  ;upgrade espressif? 5.2.0
 board = esp32doit-devkit-v1
 framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1' 
+build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1'
 lib_deps = 
-  ${common.lib_deps_esp32}
-  mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-  ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
+	${common.lib_deps_esp32}
+	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
+	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 extra_scripts = ${common.extra_scripts}
+;board_build.partitions = min_spiffs.csv
 
 [env:esp32doit-devkit-v1-debug]
-;ARDUINO_ESP32_DEV
 monitor_speed = 115200
 build_type = debug
-monitor_filters = default, log2file, esp32_exception_decoder
-;board_build.partitions = min_spiffs.csv
+monitor_filters = 
+	default
+	log2file
+	esp32_exception_decoder
+platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
 lang = fr
-platform = espressif32@4.1.0  ;upgrade espressif? 5.2.0
 board = esp32doit-devkit-v1
 framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1' 
+build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1'
 lib_deps = 
-  ${common.lib_deps_esp32}
-  mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-  ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
+	${common.lib_deps_esp32}
+	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
+	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 extra_scripts = ${common.extra_scripts}
+;board_build.partitions = min_spiffs.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ extra_scripts = platformio_script.py
 
 [env:esp32dev_fr]
 monitor_speed = 115200
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
+platform = espressif32@4.1.0
 lang = fr
 board = esp32dev
 framework = arduino
@@ -82,7 +82,7 @@ monitor_filters =
 	default
 	log2file
 	esp32_exception_decoder
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
+platform = espressif32@4.1.0
 lang = fr
 board = esp32dev
 framework = arduino
@@ -97,7 +97,7 @@ monitor_filters =
 	default
 	log2file
 	esp32_exception_decoder
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
+platform = espressif32@4.1.0
 lang = fr
 board = esp32dev
 framework = arduino
@@ -113,7 +113,7 @@ monitor_filters =
 	default
 	log2file
 	esp32_exception_decoder
-platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
+platform = espressif32@4.1.0
 lang = fr
 board = esp32doit-devkit-v1
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,7 +65,7 @@ lib_deps_esp32 =
 
 extra_scripts = platformio_script.py
 
-[env:esp32dev-fr]
+[env:esp32dev_fr]
 monitor_speed = 115200
 platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
 lang = fr
@@ -75,7 +75,7 @@ build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
 lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}
 
-[env:esp32dev-fr-debug]
+[env:esp32dev_fr_debug]
 monitor_speed = 115200
 build_type = debug
 monitor_filters = 
@@ -90,7 +90,7 @@ build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
 lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}
 
-[env:esp32dev-en-debug]
+[env:esp32dev_en_debug]
 monitor_speed = 115200
 build_type = debug
 monitor_filters = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,21 +60,20 @@ extra_scripts = platformio_script.py
 ;platform_version_esp32 = espressif32@1.11.1 ; using Arduino core 1.0.4
 ;platform_version_esp32 = espressif32
 
-[env:esp32doit-devkit-v1]
+[env:esp32dev-fr]
 monitor_speed = 115200
 platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
 lang = fr
-board = esp32doit-devkit-v1
+board = esp32dev
 framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1'
+build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
 lib_deps = 
 	${common.lib_deps_esp32}
 	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
 	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 extra_scripts = ${common.extra_scripts}
-;board_build.partitions = min_spiffs.csv
 
-[env:esp32doit-devkit-v1-debug]
+[env:esp32dev-fr-debug]
 monitor_speed = 115200
 build_type = debug
 monitor_filters = 
@@ -83,12 +82,11 @@ monitor_filters =
 	esp32_exception_decoder
 platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
 lang = fr
-board = esp32doit-devkit-v1
+board = esp32dev
 framework = arduino
-build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1'
+build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
 lib_deps = 
 	${common.lib_deps_esp32}
 	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
 	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 extra_scripts = ${common.extra_scripts}
-;board_build.partitions = min_spiffs.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 description = Software for the DOIT ESP32 DEVKIT V1 running inside the air quality sensor ModuleAir.
 name = ModuleAir_V2.1
-default_envs = esp32dev-fr-debug
+default_envs = esp32dev_fr
 
 [common]
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -75,3 +75,20 @@ lib_deps =
   mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
   ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
 extra_scripts = ${common.extra_scripts}
+
+[env:esp32doit-devkit-v1-debug]
+;ARDUINO_ESP32_DEV
+monitor_speed = 115200
+build_type = debug
+monitor_filters = default, log2file, esp32_exception_decoder
+;board_build.partitions = min_spiffs.csv
+lang = fr
+platform = espressif32@4.1.0  ;upgrade espressif? 5.2.0
+board = esp32doit-devkit-v1
+framework = arduino
+build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1' 
+lib_deps = 
+  ${common.lib_deps_esp32}
+  mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
+  ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
+extra_scripts = ${common.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,8 @@
 
 [platformio]
 src_dir = .
+description = Software for the DOIT ESP32 DEVKIT V1 running inside the air quality sensor ModuleAir.
+name = ModuleAir_V2.1
 
 [common]
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = .
 description = Software for the DOIT ESP32 DEVKIT V1 running inside the air quality sensor ModuleAir.
 name = ModuleAir_V2.1
-default_envs = esp32doit-devkit-v1-debug
+default_envs = esp32dev-fr-debug
 
 [common]
 monitor_speed = 115200
@@ -33,9 +33,11 @@ build_flags_esp32 =
 	-D LMIC_PRINTF_TO=Serial
 build_flags_esp32_release = ${common.build_flags_esp32} -DNDEBUG
 build_flags_esp32_debug = ${common.build_flags_esp32} -g -Og -fno-inline -DUSING_JTAG_DEBUGGER_PINS=1 -DDEBUG_ESP_PORT=Serial
+
 board_build.ldscript = eagle.flash.4m3m.ld
 board_build.filesystem = spiffs
 board_build.f_cpu = 160000000L
+
 lib_deps_external = 
 	bblanchon/ArduinoJson@6.18.3
 	2dom/PxMatrix LED MATRIX library@^1.8.2
@@ -55,10 +57,13 @@ lib_deps_esp32_platform =
 	WebServer
 	Update
 	ESPmDNS
-lib_deps_esp32 = ${common.lib_deps_esp32_platform} ${common.lib_deps_external}
+lib_deps_esp32 = 
+	${common.lib_deps_esp32_platform} 
+	${common.lib_deps_external}
+	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
+	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
+
 extra_scripts = platformio_script.py
-;platform_version_esp32 = espressif32@1.11.1 ; using Arduino core 1.0.4
-;platform_version_esp32 = espressif32
 
 [env:esp32dev-fr]
 monitor_speed = 115200
@@ -67,10 +72,7 @@ lang = fr
 board = esp32dev
 framework = arduino
 build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
-lib_deps = 
-	${common.lib_deps_esp32}
-	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
+lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}
 
 [env:esp32dev-fr-debug]
@@ -85,8 +87,5 @@ lang = fr
 board = esp32dev
 framework = arduino
 build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_C'
-lib_deps = 
-	${common.lib_deps_esp32}
-	mcci-catena/MCCI LoRaWAN LMIC library@^4.1.1
-	ThingPulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.1
+lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -104,3 +104,19 @@ framework = arduino
 build_flags = ${common.build_flags_esp32_release} '-DINTL_EN' '-DKIT_C'
 lib_deps = ${common.lib_deps_esp32}
 extra_scripts = ${common.extra_scripts}
+
+
+[env:esp32doit-devkit-v1_fr_debug]
+monitor_speed = 115200
+build_type = debug
+monitor_filters = 
+	default
+	log2file
+	esp32_exception_decoder
+platform = espressif32@4.1.0 ;upgrade espressif? 5.2.0
+lang = fr
+board = esp32doit-devkit-v1
+framework = arduino
+build_flags = ${common.build_flags_esp32_release} '-DINTL_FR' '-DKIT_V1'
+lib_deps = ${common.lib_deps_esp32}
+extra_scripts = ${common.extra_scripts}


### PR DESCRIPTION
Configurations diversity similar to before, only simplified and more readable.
Added debug build flags in `_debug` envs.
Specify `esp32dev_fr` as default env.
@pjgueno 